### PR TITLE
update item_mouse_entered() signal to show emits item

### DIFF
--- a/addons/gloot/ui/ctrl_item_slot.gd
+++ b/addons/gloot/ui/ctrl_item_slot.gd
@@ -15,10 +15,10 @@ const StacksConstraint = preload("res://addons/gloot/core/constraints/stacks_con
 
 ## Emitted when the mouse enters the [Rect2] area of the control representing
 ## the given [InventoryItem].
-signal item_mouse_entered
+signal item_mouse_entered(item)
 ## Emitted when the mouse leaves the [Rect2] area of the control representing
 ## the given [InventoryItem].
-signal item_mouse_exited
+signal item_mouse_exited(item)
 
 ## Path to an [ItemSlot] node.
 @export var item_slot_path: NodePath :


### PR DESCRIPTION
Shows that its emitting item in the inspector with this change;  it currently still "works" assuming the user knows to put item as a param in their connected function, but if you don't you will end up with an error for how many paramaters you got in it. It confused the hell out of me...

![image](https://github.com/user-attachments/assets/011fd20f-49d5-48d8-9321-af9516d707fa)